### PR TITLE
chore: test merge_commit_sha

### DIFF
--- a/.github/workflows/pull-request-merged.yml
+++ b/.github/workflows/pull-request-merged.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set short git commit SHA
         id: vars


### PR DESCRIPTION
Testing:

```
- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
          ref: ${{ github.event.pull_request.merge_commit_sha }}
```